### PR TITLE
Readme badges: fix build, add Node, add ESLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ Copyright &copy; 2023, Team Pa11y
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
 [shield-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml/badge.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
+[shield-node]: https://img.shields.io/node/v/pa11y-lint-config.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config.svg

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ Copyright &copy; 2023, Team Pa11y
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
 [shield-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml/badge.svg
 [shield-eslint]: https://img.shields.io/npm/dependency-version/pa11y-lint-config/dev/eslint
-[shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
-[shield-node]: https://img.shields.io/node/v/pa11y-lint-config.svg
-[shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config.svg
+[shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue
+[shield-node]: https://img.shields.io/node/v/pa11y-lint-config
+[shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Linter configurations for Pa11y projects. We use these configurations to ensure Pa11y's coding style remains consistent across our repositories.
 
-[![NPM version][shield-npm]][info-npm]
+[![Latest version published to npm][shield-npm]][info-npm]
+[![Node.js version support][shield-node]][info-node]
 [![Build status][shield-build]][info-build]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 
@@ -64,6 +65,7 @@ Copyright &copy; 2023, Team Pa11y
 
 [info-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml
 [info-license]: LICENSE
+[info-node]: package.json
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
 [shield-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml/badge.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Linter configurations for Pa11y projects. We use these configurations to ensure 
 
 [![Latest version published to npm][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
+[![ESLint version used][shield-eslint]][shield-eslint]
 [![Build status][shield-build]][info-build]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 
@@ -68,6 +69,7 @@ Copyright &copy; 2023, Team Pa11y
 [info-node]: package.json
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
 [shield-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml/badge.svg
+[shield-eslint]: https://img.shields.io/npm/dependency-version/pa11y-lint-config/dev/eslint
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-node]: https://img.shields.io/node/v/pa11y-lint-config.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config.svg

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Linter configurations for Pa11y projects. We use these configurations to ensure 
 
 [![Latest version published to npm][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
-[![ESLint version used][shield-eslint]][shield-eslint]
+[![ESLint version target][shield-eslint]][eslint]
 [![Build status][shield-build]][info-build]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Copyright &copy; 2023, Team Pa11y
 [issues]: https://github.com/pa11y/pa11y-lint-config/issues
 [node.js]: https://nodejs.org/
 
+[info-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml
 [info-license]: LICENSE
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
-[info-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml
+[shield-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml/badge.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config.svg
-[shield-build]: https://img.shields.io/travis/pa11y/pa11y-lint-config/master.svg

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Copyright &copy; 2023, Team Pa11y
 
 [info-license]: LICENSE
 [info-npm]: https://www.npmjs.com/package/pa11y-lint-config
-[info-build]: https://travis-ci.org/pa11y/pa11y-lint-config
+[info-build]: https://github.com/pa11y/pa11y-lint-config/actions/workflows/tests.yml
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-lint-config.svg
 [shield-build]: https://img.shields.io/travis/pa11y/pa11y-lint-config/master.svg


### PR DESCRIPTION
1. Update build badge to point to GitHub Actions rather than TravisCI
2. Add badge for Node.js support, pulling from `package.json`
3. Change text for npm badge from `NPM version` to `Latest version published to npm`
4. Add badge for ESLint version target, pulling from `package.json`