### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - run: npm publish --dry-run
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       dryRun:
         description: 'Dry run only'
+        required: true
         default: true
         type: boolean
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,25 +13,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 20
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm ci
-    
-    - name: Publish package
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
-      if: >
-        (github.event_name == 'release' && github.event.action == 'published') ||
-        (github.event_name == 'workflow_dispatch' && inputs.dryRun != 'true')
-      run: npm publish
-    
-    - name: Publish package (dry run)
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
-      if: >
-        (github.event_name == 'release' && github.event.action != 'published') ||
-        (github.event_name == 'workflow_dispatch' && inputs.dryRun == 'true')
-      run: npm publish --dry-run
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+        if: >
+          (github.event_name == 'release' && github.event.action == 'published') ||
+          (github.event_name == 'workflow_dispatch' && inputs.dryRun != 'true')
+        run: npm publish
+      
+      - name: Publish package (dry run)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+        if: >
+          (github.event_name == 'release' && github.event.action != 'published') ||
+          (github.event_name == 'workflow_dispatch' && inputs.dryRun == 'true')
+        run: npm publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,12 @@
 on:
   release:
-    types: [published]
+    types: [created, edited, published]
   workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run only'
+        default: true
+        type: boolean
 
 jobs:
   build:
@@ -13,6 +18,19 @@ jobs:
         node-version: 20
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
-    - run: npm publish --dry-run
+    
+    - name: Publish package
       env:
         NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+      if: >
+        (github.event_name == 'release' && github.event.action == 'published') ||
+        (github.event_name == 'workflow_dispatch' && inputs.dryRun != 'true')
+      run: npm publish
+    
+    - name: Publish package (dry run)
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+      if: >
+        (github.event_name == 'release' && github.event.action != 'published') ||
+        (github.event_name == 'workflow_dispatch' && inputs.dryRun == 'true')
+      run: npm publish --dry-run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 


### PR DESCRIPTION
This PR brings package publishing into GitHub Actions.

- Retains a manual trigger
    - A GitHub Release
    - `workflow_dispatch`
- Will be published by [pa11y-bot](https://www.npmjs.com/~pa11y-bot)

Effects:
- Dry run publish triggered on:
    - Manual triggering with `Dry run only` ticked (default)
    - Ideally, a release draft `created` or `edited` (but this is [not yet supported by GitHub Actions](https://github.com/orgs/community/discussions/7118))
- Full publish triggered on:
    - Release published
    - Manual triggered with `Dry run only` unticked
    
Also:
- remove `master` as push trigger target for tests

## Remaining tasks

- [x] Complete setup at npmjs.org
- [x] Add publishing key secret to this repo
- [x] Refactor to extract `--dry-run`
