### PR TITLE
Fix boolean treatment of `dryRun`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
         if: >
           (github.event_name == 'release' && github.event.action == 'published') ||
-          (github.event_name == 'workflow_dispatch' && inputs.dryRun != 'true')
+          (github.event_name == 'workflow_dispatch' && !inputs.dryRun)
         run: npm publish
       
       - name: Publish package (dry run)
@@ -33,5 +33,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
         if: >
           (github.event_name == 'release' && github.event.action != 'published') ||
-          (github.event_name == 'workflow_dispatch' && inputs.dryRun == 'true')
+          (github.event_name == 'workflow_dispatch' && inputs.dryRun)
         run: npm publish --dry-run


### PR DESCRIPTION
Theory: `dryRun` can/should be treated as a boolean in this context.  There are some [inconsistencies between contexts](https://stackoverflow.com/questions/76292948/github-action-boolean-input-with-default-value) → confusion.  I can test this workflow file properly now that GA knows about the file.

Testing (with bad key for safety):

✅ Dry run: [runs/6642484803/job/18047350738](https://github.com/pa11y/pa11y-lint-config/actions/runs/6642484803/job/18047350738)
✅ Full publish: (chose correct path) [runs/6642517927/job/18047460345](https://github.com/pa11y/pa11y-lint-config/actions/runs/6642517927/job/18047460345)