### PR TITLE
Release `pa11y-lint-config@3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog
 
+## 3.0.0 (2023-10-26)
+
+* Support current Node.js LTS (18, 20)
+* Update ESLint version to `^8.51.0`
+* Set es2017 as default
+* Drop `es2015`'s alias `es6`
+* Drop `legacy`'s alias `es5`
+* Rename `legacy` to `es2009`
+* Add support policy
+
 ## 2.0.0 (2021-05-26)
 
 * Update Node requirements to LTS

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Please check that everything works by running the following before opening a <ab
 npm test
 ```
 
+## Support
+
+When we release a new major version we will continue to support the previous major version for 6 months. This support will be limited to fixes for critical bugs and security issues.
+
 ## Licence
 
 Licensed under the [Lesser General Public License (LGPL-3.0)](LICENSE).<br/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-lint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-lint-config",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "LGPL-3.0",
       "devDependencies": {
         "eslint": "^8.51.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-lint-config",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Linter configurations for Pa11y projects",
   "author": "Team Pa11y",
   "contributors": [


### PR DESCRIPTION
This PR updates the package to version 3.  Changes are listed in the changelog.  Releasing it will also test the new publishing workflow.  Also adds new support policy.