### PR TITLE
Convert to ESLint Shareable Config, `eslint-config-pa11y`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: 'Dry run only'
+        description: Dry run only
         required: true
         default: true
         type: boolean
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: https://registry.npmjs.org
       - run: npm ci
       
       - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [18, 20]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -25,7 +25,7 @@ jobs:
         node-version: [18, 20]    
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,3 +17,36 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
+
+  use-in-a-client-project:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]    
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - name: Pack the shareable config
+        run: |
+          mkdir ${{ runner.temp }}/packed-eslint-config-pa11y
+          npm pack --pack-destination ${{ runner.temp }}/packed-eslint-config-pa11y
+      
+      - name: Create the client project
+        working-directory: ${{ runner.temp }}
+        run: |
+          mkdir client-project
+          cd client-project
+          npm init -y
+          touch index.js
+
+      - name: Install the packed shareable config
+        working-directory: ${{ runner.temp }}/client-project
+        run: |
+          npm install --save-dev ../packed-eslint-config-pa11y/*.tgz
+          echo '{ "extends": "pa11y" }' > .eslintrc.json
+
+      - name: Check peer dependencies and use the shareable config
+        run: npx --no eslint .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,8 @@ jobs:
       - run: npm ci
       - name: Pack the shareable config
         run: |
-          mkdir ${{ runner.temp }}/packed-eslint-config-pa11y
-          npm pack --pack-destination ${{ runner.temp }}/packed-eslint-config-pa11y
+          mkdir ${{ runner.temp }}/packed
+          npm pack --pack-destination ${{ runner.temp }}/packed
       
       - name: Create the client project
         working-directory: ${{ runner.temp }}
@@ -45,7 +45,7 @@ jobs:
       - name: Install the packed shareable config
         working-directory: ${{ runner.temp }}/client-project
         run: |
-          npm install --save-dev ../packed-eslint-config-pa11y/*.tgz
+          npm install --save-dev ../packed/*.tgz
           echo '{ "extends": "pa11y" }' > .eslintrc.json
 
       - name: Check peer dependencies and use the shareable config

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - name: Pack the shareable config
+      - name: Pack our shareable config
         run: |
           mkdir ${{ runner.temp }}/packed
           npm pack --pack-destination ${{ runner.temp }}/packed
       
-      - name: Create the client project
+      - name: Create a client project
         working-directory: ${{ runner.temp }}
         run: |
           mkdir some-project
@@ -42,12 +42,12 @@ jobs:
           npm init -y
           touch index.js
 
-      - name: Install the packed shareable config
+      - name: Install our config in the client project
         working-directory: ${{ runner.temp }}/some-project
         run: |
           npm install --save-dev ../packed/*.tgz
 
-      - name: Use the shareable config (also checks peer dependencies)
+      - name: Use shareable config (also checks peer dependencies)
         working-directory: ${{ runner.temp }}/some-project
         run: |
           echo '{ "extends": "pa11y" }' > .eslintrc.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,16 +37,18 @@ jobs:
       - name: Create the client project
         working-directory: ${{ runner.temp }}
         run: |
-          mkdir client-project
-          cd client-project
+          mkdir some-project
+          cd some-project
           npm init -y
           touch index.js
 
       - name: Install the packed shareable config
-        working-directory: ${{ runner.temp }}/client-project
+        working-directory: ${{ runner.temp }}/some-project
         run: |
           npm install --save-dev ../packed/*.tgz
-          echo '{ "extends": "pa11y" }' > .eslintrc.json
 
-      - name: Check peer dependencies and use the shareable config
-        run: npx --no eslint .
+      - name: Use the shareable config (also checks peer dependencies)
+        working-directory: ${{ runner.temp }}/some-project
+        run: |
+          echo '{ "extends": "pa11y" }' > .eslintrc.json
+          npx --no eslint .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pa11y-lint-config",
+  "name": "eslint-config-pa11y",
   "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pa11y-lint-config",
+      "name": "eslint-config-pa11y",
       "version": "3.0.0",
       "license": "LGPL-3.0",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pa11y-lint-config",
+  "name": "eslint-config-pa11y",
   "version": "3.0.0",
   "description": "Linter configurations for Pa11y projects",
   "author": "Team Pa11y",


### PR DESCRIPTION
This PR updates the project to become an ESLint Shareable Config and adds a test in CI to verify that it can be installed and used.  These insist on the prefix `eslint`.

### Changes

- Rename `package.name` to `eslint-config-pa11y` from `pa11y-lint-config`
- Test installation and usage of the config into a temporary project in GitHub Actions, referencing it by the name `pa11y`
    - this can be parameterised in future to cover specific versions of ESLint
