### PR TITLE
Move towards consistency with other Pa11y projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[package.json]
+indent_style = space
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 ## 4.0.0 (2023-11-13)
 
 * Publish package as [ESLint Shareable Config](https://eslint.org/docs/latest/extend/shareable-configs):
-  * Publish as `eslint-config-pa11y`
-  * Deprecate all published packages `pa11y-lint-config`
-* Drop configs no longer used by the pa11y org (`es2009`, `es2015`)
-* Rename sole remaining config to `es2020` and:
-  * Update `ecmaVersion` to `2020` from `2017`
+  * Publish as the flat config `eslint-config-pa11y`
+* Use ES2020, dropping configs no longer used by the pa11y org (`es2009`, `es2015`)
 
 ## 3.0.0 (2023-10-26)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pa11y Lint Config
+# eslint-config-pa11y
 
 Linter configuration for Pa11y projects. We use this configuration to ensure Pa11y's coding style remains consistent across our repositories.
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Add `--verbose` to any `act` command for more output.
 
 When we release a new major version we will continue to support the previous major version for 6 months. This support will be limited to fixes for critical bugs and security issues.
 
-## Licence
+## License
 
-Licensed under the [Lesser General Public License (LGPL-3.0)](LICENSE).<br/>
+Licensed under the [Lesser General Public License (LGPL-3.0)][info-license].<br/>
 Copyright &copy; 2017-2025, Team Pa11y
 
 


### PR DESCRIPTION
This PR is a consistency pass, including:

- [x] updates the heading to `eslint-config-pa11y`, the name of the published package
- [x] adds an Editor Config, matching our other repos'